### PR TITLE
Added timeouts to the cURL API request

### DIFF
--- a/app/code/community/Belco/Widget/Model/Api.php
+++ b/app/code/community/Belco/Widget/Model/Api.php
@@ -115,6 +115,8 @@ class Belco_Widget_Model_Api
     $this->logger->log("Data: " . $data);
 
     $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 2);            // Connect within 2 seconds
+    curl_setopt($ch, CURLOPT_TIMEOUT, 5);                   // API should reply within 5 seconds
     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_HTTPHEADER, array(


### PR DESCRIPTION
In order to prevent the checkout process from failing when the API suffers downtime, timeouts should be added so the connection is being dropped and the API may still be processed.

Additionally the throw Exception may be removed as well, so the connection drop does not make the checkout fail.